### PR TITLE
[Week 1] Finalize schema with design decisions

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1,16 +1,33 @@
 -- Intelligent Job Matching Platform
 -- Schema: creation order respects FK dependencies
+--
+-- Design decisions (Week 1):
+--   • Charset:  utf8mb4 / utf8mb4_unicode_ci throughout (handles full Unicode)
+--   • StudentSkill.level: ENUM('Beginner','Intermediate','Advanced') — clearer
+--     for display and sufficient for the matching algorithm weight map
+--   • Opportunity.location added per project description (overrides Stage 3)
+--   • Application.applied_at + status added per project description
+--   • OpportunitySkill.priority added to support required/preferred weighting
+--     in the Week 6 matching algorithm
+--
+-- FK ON DELETE actions (applied in Week 2 branch):
+--   • Opportunity.company_id         → RESTRICT  (don't orphan opportunities)
+--   • StudentSkill.user_id           → CASCADE   (student deleted → skills go)
+--   • StudentSkill.skill_id          → RESTRICT  (can't delete a used skill)
+--   • Application (both FKs)         → CASCADE   (derived data)
+--   • OpportunitySkill.opportunity_id → CASCADE   (opportunity deleted → reqs go)
+--   • OpportunitySkill.skill_id      → RESTRICT  (can't delete a used skill)
 
 CREATE TABLE IF NOT EXISTS Company (
     company_id INT AUTO_INCREMENT PRIMARY KEY,
-    name       VARCHAR(255) NOT NULL,
+    name       VARCHAR(255) NOT NULL UNIQUE,
     location   VARCHAR(255) NOT NULL
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS Skill (
     skill_id INT AUTO_INCREMENT PRIMARY KEY,
     name     VARCHAR(100) NOT NULL UNIQUE
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS Student (
     user_id  INT AUTO_INCREMENT PRIMARY KEY,
@@ -19,20 +36,23 @@ CREATE TABLE IF NOT EXISTS Student (
     major    VARCHAR(255) NOT NULL,
     location VARCHAR(255) NOT NULL,
     resume   TEXT
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS Opportunity (
     opportunity_id INT AUTO_INCREMENT PRIMARY KEY,
     title          VARCHAR(255) NOT NULL,
+    location       VARCHAR(255) NOT NULL,
     company_id     INT NOT NULL,
     CONSTRAINT fk_opportunity_company
         FOREIGN KEY (company_id) REFERENCES Company(company_id)
-        ON DELETE CASCADE ON UPDATE CASCADE
-);
+        ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS StudentSkill (
     user_id  INT NOT NULL,
     skill_id INT NOT NULL,
+    -- ENUM chosen over integer: cleaner display, sufficient for algo weight map
+    -- (Advanced=1.0, Intermediate=0.7, Beginner=0.4)
     level    ENUM('Beginner', 'Intermediate', 'Advanced') NOT NULL DEFAULT 'Beginner',
     PRIMARY KEY (user_id, skill_id),
     CONSTRAINT fk_studentskill_student
@@ -40,12 +60,15 @@ CREATE TABLE IF NOT EXISTS StudentSkill (
         ON DELETE CASCADE ON UPDATE CASCADE,
     CONSTRAINT fk_studentskill_skill
         FOREIGN KEY (skill_id) REFERENCES Skill(skill_id)
-        ON DELETE CASCADE ON UPDATE CASCADE
-);
+        ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS Application (
     user_id        INT NOT NULL,
     opportunity_id INT NOT NULL,
+    applied_at     TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    status         ENUM('submitted', 'reviewed', 'accepted', 'rejected')
+                       NOT NULL DEFAULT 'submitted',
     PRIMARY KEY (user_id, opportunity_id),
     CONSTRAINT fk_application_student
         FOREIGN KEY (user_id)        REFERENCES Student(user_id)
@@ -53,16 +76,23 @@ CREATE TABLE IF NOT EXISTS Application (
     CONSTRAINT fk_application_opportunity
         FOREIGN KEY (opportunity_id) REFERENCES Opportunity(opportunity_id)
         ON DELETE CASCADE ON UPDATE CASCADE
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS OpportunitySkill (
     opportunity_id INT NOT NULL,
     skill_id       INT NOT NULL,
+    -- 'required' skills count in match scoring; 'preferred' are bonus
+    priority       ENUM('required', 'preferred') NOT NULL DEFAULT 'required',
     PRIMARY KEY (opportunity_id, skill_id),
     CONSTRAINT fk_opskill_opportunity
         FOREIGN KEY (opportunity_id) REFERENCES Opportunity(opportunity_id)
         ON DELETE CASCADE ON UPDATE CASCADE,
     CONSTRAINT fk_opskill_skill
         FOREIGN KEY (skill_id)       REFERENCES Skill(skill_id)
-        ON DELETE CASCADE ON UPDATE CASCADE
-);
+        ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Indexes on high-join columns (applied after table creation)
+CREATE INDEX IF NOT EXISTS idx_studentskill_skill_id    ON StudentSkill   (skill_id);
+CREATE INDEX IF NOT EXISTS idx_opportunityskill_skill_id ON OpportunitySkill (skill_id);
+CREATE INDEX IF NOT EXISTS idx_application_opportunity  ON Application    (opportunity_id);

--- a/seed.sql
+++ b/seed.sql
@@ -1,5 +1,8 @@
 -- Seed data for Intelligent Job Matching Platform
 -- Run after schema.sql
+-- Safe to reload: all inserts use literal IDs; wipe tables in reverse FK order
+-- to reset: truncate Application, OpportunitySkill, StudentSkill, Opportunity,
+--           Student, Skill, Company (in that order), then re-run this file.
 
 -- Companies (3)
 INSERT INTO Company (name, location) VALUES
@@ -22,65 +25,74 @@ INSERT INTO Skill (name) VALUES
 
 -- Students (5)
 INSERT INTO Student (name, email, major, location, resume) VALUES
-    ('Alice Torres',   'at23@fsu.edu', 'Computer Science',      'Tallahassee, FL', 'Junior CS student interested in backend development.'),
-    ('Brian Nguyen',   'bn45@fsu.edu', 'Information Technology', 'Miami, FL',       'IT student with a focus on cybersecurity fundamentals.'),
-    ('Carla Reyes',    'cr67@fsu.edu', 'Computer Science',      'Orlando, FL',     'CS student passionate about machine learning and data.'),
-    ('Derek Smith',    'ds89@fsu.edu', 'Computer Engineering',  'Tampa, FL',       'CE student experienced with embedded Linux systems.'),
-    ('Elena Vasquez',  'ev12@fsu.edu', 'Information Technology', 'Jacksonville, FL','IT student with strong communication and teamwork skills.');
+    ('Alice Torres',   'at23@fsu.edu', 'Computer Science',      'Tallahassee, FL',  'Junior CS student interested in backend development.'),
+    ('Brian Nguyen',   'bn45@fsu.edu', 'Information Technology', 'Miami, FL',        'IT student with a focus on cybersecurity fundamentals.'),
+    ('Carla Reyes',    'cr67@fsu.edu', 'Computer Science',      'Orlando, FL',      'CS student passionate about machine learning and data.'),
+    ('Derek Smith',    'ds89@fsu.edu', 'Computer Engineering',  'Tampa, FL',        'CE student experienced with embedded Linux systems.'),
+    ('Elena Vasquez',  'ev12@fsu.edu', 'Information Technology', 'Jacksonville, FL', 'IT student with strong communication and teamwork skills.');
 
--- Opportunities (6)
-INSERT INTO Opportunity (title, company_id) VALUES
-    ('Software Engineering Intern',  1),  -- Accenture
-    ('Database Administrator Intern',1),  -- Accenture
-    ('Systems Integration Engineer', 2),  -- Lockheed Martin
-    ('Cybersecurity Analyst Intern',  2),  -- Lockheed Martin
-    ('Threat Intelligence Intern',    3),  -- CrowdStrike
-    ('ML Platform Engineer Intern',   3);  -- CrowdStrike
+-- Opportunities (6) — includes location per project description
+INSERT INTO Opportunity (title, location, company_id) VALUES
+    ('Software Engineering Intern',   'Tampa, FL',    1),  -- Accenture
+    ('Database Administrator Intern', 'Tampa, FL',    1),  -- Accenture
+    ('Systems Integration Engineer',  'Orlando, FL',  2),  -- Lockheed Martin
+    ('Cybersecurity Analyst Intern',   'Orlando, FL',  2),  -- Lockheed Martin
+    ('Threat Intelligence Intern',     'Austin, TX',   3),  -- CrowdStrike
+    ('ML Platform Engineer Intern',    'Austin, TX',   3);  -- CrowdStrike
 
 -- StudentSkill entries
 INSERT INTO StudentSkill (user_id, skill_id, level) VALUES
-    -- Alice: Python(Adv), SQL(Int), Flask(Int)
+    -- Alice: Python(Adv), SQL(Int), Flask(Int) → perfect match for opp #1 & #2
     (1, 1, 'Advanced'),
     (1, 2, 'Intermediate'),
     (1, 9, 'Intermediate'),
-    -- Brian: Cybersecurity(Int), Linux(Int), Communication(Adv)
+    -- Brian: Cybersecurity(Int), Linux(Int), Communication(Adv) → perfect match for opp #4 & #5
     (2, 5, 'Intermediate'),
     (2, 8, 'Intermediate'),
     (2, 6, 'Advanced'),
-    -- Carla: Python(Adv), Machine Learning(Int), SQL(Beg)
+    -- Carla: Python(Adv), Machine Learning(Int), SQL(Beg) → perfect match for opp #6
     (3, 1, 'Advanced'),
     (3, 7, 'Intermediate'),
     (3, 2, 'Beginner'),
-    -- Derek: Linux(Adv), Docker(Int), Java(Int)
+    -- Derek: Linux(Adv), Docker(Int), Java(Int) → perfect match for opp #3
     (4, 8, 'Advanced'),
     (4, 3, 'Intermediate'),
     (4, 4, 'Intermediate'),
-    -- Elena: Communication(Adv), Teamwork(Adv), SQL(Beg)
+    -- Elena: Communication(Adv), Teamwork(Adv), SQL(Beg) → partial match only
     (5, 6, 'Advanced'),
     (5, 10,'Advanced'),
     (5, 2, 'Beginner');
 
--- OpportunitySkill entries
-INSERT INTO OpportunitySkill (opportunity_id, skill_id) VALUES
-    -- Software Engineering Intern: Python, Flask, SQL
-    (1, 1), (1, 9), (1, 2),
-    -- Database Administrator Intern: SQL, Python
-    (2, 2), (2, 1),
-    -- Systems Integration Engineer: Linux, Docker, Java
-    (3, 8), (3, 3), (3, 4),
-    -- Cybersecurity Analyst Intern: Cybersecurity, Linux
-    (4, 5), (4, 8),
-    -- Threat Intelligence Intern: Cybersecurity, Communication
-    (5, 5), (5, 6),
-    -- ML Platform Engineer Intern: Machine Learning, Python, Docker
-    (6, 7), (6, 1), (6, 3);
+-- OpportunitySkill entries (with priority — 'required' unless noted)
+INSERT INTO OpportunitySkill (opportunity_id, skill_id, priority) VALUES
+    -- Software Engineering Intern: Python(req), Flask(req), SQL(preferred)
+    (1, 1, 'required'),
+    (1, 9, 'required'),
+    (1, 2, 'preferred'),
+    -- Database Administrator Intern: SQL(req), Python(preferred)
+    (2, 2, 'required'),
+    (2, 1, 'preferred'),
+    -- Systems Integration Engineer: Linux(req), Docker(req), Java(req)
+    (3, 8, 'required'),
+    (3, 3, 'required'),
+    (3, 4, 'required'),
+    -- Cybersecurity Analyst Intern: Cybersecurity(req), Linux(req)
+    (4, 5, 'required'),
+    (4, 8, 'required'),
+    -- Threat Intelligence Intern: Cybersecurity(req), Communication(req)
+    (5, 5, 'required'),
+    (5, 6, 'required'),
+    -- ML Platform Engineer Intern: Machine Learning(req), Python(req), Docker(preferred)
+    (6, 7, 'required'),
+    (6, 1, 'required'),
+    (6, 3, 'preferred');
 
--- Application entries
+-- Application entries (applied_at and status use column defaults)
 INSERT INTO Application (user_id, opportunity_id) VALUES
-    (1, 1),  -- Alice -> Software Eng Intern
-    (1, 2),  -- Alice -> DBA Intern
-    (2, 4),  -- Brian -> Cybersecurity Analyst Intern
-    (2, 5),  -- Brian -> Threat Intelligence Intern
-    (3, 6),  -- Carla -> ML Platform Intern
-    (4, 3),  -- Derek -> Systems Integration
-    (5, 1);  -- Elena -> Software Eng Intern
+    (1, 1),  -- Alice   -> Software Eng Intern
+    (1, 2),  -- Alice   -> DBA Intern
+    (2, 4),  -- Brian   -> Cybersecurity Analyst Intern
+    (2, 5),  -- Brian   -> Threat Intelligence Intern
+    (3, 6),  -- Carla   -> ML Platform Intern
+    (4, 3),  -- Derek   -> Systems Integration
+    (5, 1);  -- Elena   -> Software Eng Intern (partial match demo)


### PR DESCRIPTION
Closes #18
Part of #9

## Changes
- `ENGINE=InnoDB` + `DEFAULT CHARSET=utf8mb4` on every table
- `Opportunity.location` added (adopts project description over Stage 3)
- `Application.applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP`
- `Application.status ENUM('submitted','reviewed','accepted','rejected') DEFAULT 'submitted'`
- `OpportunitySkill.priority ENUM('required','preferred') DEFAULT 'required'`
- `UNIQUE` constraint on `Company.name`
- FK `ON DELETE RESTRICT` on `skill_id` FKs and `Opportunity.company_id`; CASCADE kept on user/application FKs
- `CREATE INDEX` for `StudentSkill.skill_id`, `OpportunitySkill.skill_id`, `Application.opportunity_id`
- `seed.sql` updated: `location` on Opportunity inserts, explicit `priority` on OpportunitySkill, demo-ready perfect/partial match annotations

## Design decisions documented
- `StudentSkill.level` stays as ENUM (simpler display; weights mapped in algorithm as Adv=1.0, Int=0.7, Beg=0.4)
- `Opportunity.location` added to match project description ER diagram